### PR TITLE
Update my_panel.py

### DIFF
--- a/my_panel.py
+++ b/my_panel.py
@@ -158,7 +158,7 @@ class MyPanelCommand(sublime_plugin.WindowCommand):
 			MyPanelCommand.mark = text
 		else:
 			if "\\w{0,3}" not in text:
-				text = re.escape(text)
+				text = re.escape(text); text = text.replace(r"\`", "`")
 			MyPanelCommand.mark = text
 		sublime.set_clipboard(text)	# This exists for the user convenience as s/he may want to use the pattern to find the "needle" by other means, for instance, by ctrl+f
 		return text


### PR DESCRIPTION
Found a special case that needs to be handled. It's regarding the backtick character, which will become "\`" from re.escape() whereas view.find_all() expects just "`". "\`" simply doesn't work, makes it not found. It's another kind of inconsistency between Python and Sublime Text 3, i guess.